### PR TITLE
chore(ci): add workflow_dispatch event for rebuilding released images (INFRA-13)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,12 +4,13 @@ on:
   push:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
-  
+
   # build allways
   build:
-    name: Build allways and publish on release
+    name: Build allways and publish on release or rebuild
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,12 +28,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - name: Build (allways) and push (on release)
+      - name: Build (allways) and push (on release or rebuild)
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: ${{ github.event_name == 'release' }}
-          tags: daschswiss/nginx-server:latest, daschswiss/nginx-server:${{ steps.get_version.outputs.VERSION }}
+          push: ${{ (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags')) || github.event_name == 'release' }}
+          # Pull and no-cache ensure that a rebuild uses the latest base image
+          # and that apt-get update/upgrade are run again
+          pull: ${{ github.event_name == 'workflow_dispatch' }}
+          no-cache: ${{ github.event_name == 'workflow_dispatch' }}
+          tags: daschswiss/nginx-server:latest, daschswiss/nginx-server:${{ steps.get_version.outputs.VERSION }}${{ (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_number)) || '' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ LABEL maintainer="400790+subotic@users.noreply.github.com"
 
 ENV NGINX_PORT 4200
 
+## Update packages
+RUN apt-get update && apt-get -y upgrade && rm -rf /var/lib/apt/lists/*
+
 ## Copy nginx config template
 COPY config.template /etc/nginx/conf.d/config.template
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ Custom Nginx docker image allowing configuration through environment variables a
 
 - Environment variable `NGINX_PORT`: port on which the server listens (default: `4200`)
 - `/public`: default directory from which files are served
+
+## Rebuilding released docker image
+Released docker images can be rebuilt and updated by manually triggering the CI workflow: Actions -> CI -> Run workflow -> Select release tag as branch -> Run Workflow. This builds the image from the same source as the release, but updates the installed apt packages. The new release is tagged with the same version appended with `-<build_nr>`, e.g., `v1.0.1-123`.


### PR DESCRIPTION
This PR adds a manual trigger to enable rebuilding and updating of already released images. This will allow us to do quick security patches when needed. Updating the nginx base image will be taken care of by dependabot.